### PR TITLE
Improve .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: ruby
+
+sudo: false
+
+cache: bundler
+
 rvm:
-  - "2.2.1"
+  - 2.0.0
+  - 2.1
+  - 2.2
 
 script: bash headless_rspec.sh
 install: gem install rspec headless; bundle install;


### PR DESCRIPTION
A new version of Ruby has come out since we last updated this, so I
added it to our testing matrix. I also changed 2.2.1 to 2.2 so that
2.2.x will be tested instead of specifically 2.2.1.

Setting `sudo: false` will allow Travis to use the faster
container-based infrastructure [0]. And `cache: bundler` will enable
Travis to persist the bundler directory between builds, making our
builds faster [1].

[0]: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
[1]: http://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)