### PR TITLE
Pass list of examples from JS to Ruby

### DIFF
--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -1,52 +1,42 @@
 'use strict';
 
 window.diffux = {
-  defined: [],
-  currentIndex: 0,
-  currentExample: undefined,
+  defined: {},
   currentRenderedElement: undefined,
   errors: [],
 
   define: function(description, func, options) {
-    this.defined.push({
+    // Make sure we don't have a duplicate description
+    if (this.defined[description]) {
+      throw 'Error while defining "' + description +
+        '": Duplicate description detected'
+    }
+    this.defined[description] = {
       description: description,
       func: func,
       options: options || {}
-    });
+    };
   },
 
   fdefine: function() {
-    this.defined = []; // clear out all previously added examples
+    this.defined = {}; // clear out all previously added examples
     this.define.apply(this, arguments); // add the example
     this.define = function() {}; // make `define` a no-op from now on
   },
 
-  next: function() {
-    if (this.currentRenderedElement) {
-      if (window.React) {
-        window.React.unmountComponentAtNode(document.body.lastChild);
-      } else {
-        this.currentRenderedElement.parentNode
-          .removeChild(this.currentRenderedElement);
-      }
-    }
-    this.currentExample = this.defined[this.currentIndex];
-    if (!this.currentExample) {
-      return;
-    }
-    this.currentIndex++;
-    return this.currentExample;
-  },
-
-  setCurrent: function(exampleDescription) {
-    this.defined.forEach(function(example, index) {
-      if (example.description === exampleDescription) {
-        this.currentExample = example;
-      }
+  /**
+   * @return {Array.<String>}
+   */
+  getAllExamples: function() {
+    return Object.keys(this.defined).map(function(description) {
+      var example = this.defined[description];
+      // We return a subset of the properties of an example (only those relevant
+      // for diffux_runner.rb).
+      return {
+        description: example.description,
+        options: example.options,
+      };
     }.bind(this));
-    if (!this.currentExample) {
-      throw 'No example found with description "' + exampleDescription + '"';
-    }
   },
 
   isElementVisible: function(element) {
@@ -66,10 +56,10 @@ window.diffux = {
     }
   },
 
-  handleError: function(error) {
+  handleError: function(currentExample, error) {
     console.error(error);
     return {
-      description: this.currentExample.description,
+      description: currentExample.description,
       error: error.message
     };
   },
@@ -106,36 +96,54 @@ window.diffux = {
     });
   },
 
+  cleanUpPreviousExample: function() {
+    if (this.currentRenderedElement) {
+      if (window.React) {
+        window.React.unmountComponentAtNode(document.body.lastChild);
+      } else {
+        this.currentRenderedElement.parentNode
+          .removeChild(this.currentRenderedElement);
+      }
+    }
+  },
+
   /**
+   * @param {String} exampleDescription
    * @param {Function} doneFunc injected by driver.execute_async_script in
    *   diffux_ci_runner.rb
    */
-  renderCurrent: function(doneFunc) {
+  renderExample: function(exampleDescription, doneFunc) {
+    var currentExample = this.defined[exampleDescription];
+    if (!currentExample) {
+      throw 'No example found with description "' + exampleDescription + '"';
+    }
+
     try {
+      this.cleanUpPreviousExample();
       this.clearVisibleElements();
 
-      var func = this.currentExample.func;
+      var func = currentExample.func;
       if (func.length) {
         // The function takes an argument, which is a callback that is called
         // once it is done executing. This can be used to write functions that
         // have asynchronous code in them.
         this.tryAsync(func).then(function(elem) {
-          doneFunc(this.processElem(elem));
+          doneFunc(this.processElem(currentExample, elem));
         }.bind(this)).catch(function(error) {
-          doneFunc(this.handleError(error));
+          doneFunc(this.handleError(currentExample, error));
         }.bind(this));
       } else {
         // The function does not take an argument, so we can run it
         // synchronously.
         var elem = func();
-        doneFunc(this.processElem(elem));
+        doneFunc(this.processElem(currentExample, elem));
       }
     } catch (error) {
-      doneFunc(this.handleError(error));
+      doneFunc(this.handleError(currentExample, error));
     }
   },
 
-  processElem: function(elem) {
+  processElem: function(currentExample, elem) {
     try {
       // TODO: elem.getDOMNode is deprecated in React, so we need to convert
       // this to ReactDOM.findDOMNode(elem) at some point, or push this
@@ -149,7 +157,7 @@ window.diffux = {
       this.currentRenderedElement = elem;
 
       var rect;
-      if (this.currentExample.options.snapshotEntireScreen) {
+      if (currentExample.options.snapshotEntireScreen) {
         rect = {
           width: window.innerWidth,
           height: window.innerHeight,
@@ -168,14 +176,14 @@ window.diffux = {
       }
 
       return {
-        description: this.currentExample.description,
+        description: currentExample.description,
         width: Math.ceil(rect.width),
         height: Math.ceil(rect.height),
         top: Math.floor(rect.top),
         left: Math.floor(rect.left),
       };
     } catch (error) {
-      return this.handleError(error);
+      return this.handleError(currentExample, error);
     }
   }
 };
@@ -186,8 +194,7 @@ window.addEventListener('load', function() {
     return;
   }
   var example = decodeURIComponent(matches[1]);
-  window.diffux.setCurrent(example);
-  window.diffux.renderCurrent(function() {});
+  window.diffux.renderExample(example, function() {});
 });
 
 // We need to redefine a few global functions that halt execution. Without this,

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -297,7 +297,7 @@ describe 'diffux_ci' do
     end
 
     it 'logs the error' do
-      expect(run_diffux[:std_err]).to include('Error while rendering "foo"')
+      expect(run_diffux[:std_err]).to include('Error while defining \"foo\"')
     end
   end
 end


### PR DESCRIPTION
Instead of iterating blindly until we run out of examples, we now first
get a list of all examples and then use that list to iterate. This will
help an upcoming change to parallellize execution.

Since I changed the array of defined examples into a hash/object, I had
to move the duplicate description introduced in e45442a into javascript
land.