### PR TITLE
Make `fdefine` work for multiple examples simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ in your project.
 
 During development, you might want to zoom in/focus on a single example. In
 those situations, you can use the `diffux.fdefine` function instead of
-`diffux.define`. Using `fdefine` will cause `diffux` to only run for that
-example.
+`diffux.define`. Using `fdefine` will cause `diffux` to only run for the
+examples that are using `fdefine` and skip all examples using `define`.
 
 ### Setting viewport sizes
 

--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -2,6 +2,7 @@
 
 window.diffux = {
   defined: {},
+  fdefined: [],
   currentRenderedElement: undefined,
   errors: [],
 
@@ -18,17 +19,26 @@ window.diffux = {
     };
   },
 
-  fdefine: function() {
-    this.defined = {}; // clear out all previously added examples
-    this.define.apply(this, arguments); // add the example
-    this.define = function() {}; // make `define` a no-op from now on
+  fdefine: function(description, func, options) {
+    this.define(description, func, options); // add the example
+    this.fdefined.push(description);
   },
 
   /**
    * @return {Array.<String>}
    */
   getAllExamples: function() {
-    return Object.keys(this.defined).map(function(description) {
+    var descriptions = Object.keys(this.defined);
+
+    if (this.fdefined.length) {
+      // Some examples have been focused, so we want to filter out anything that
+      // has not been focused.
+      descriptions = descriptions.filter(function(description) {
+        return this.fdefined.indexOf(description) !== -1;
+      }.bind(this));
+    }
+
+    return descriptions.map(function(description) {
       var example = this.defined[description];
       // We return a subset of the properties of an example (only those relevant
       // for diffux_runner.rb).

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -305,6 +305,38 @@ describe 'diffux_ci' do
     end
   end
 
+  describe 'when multiple examples are defined' do
+    let(:examples_js) { <<-EOS }
+      diffux.define('foo', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Foo';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+
+      diffux.define('bar', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Bar';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+
+      diffux.define('baz', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Baz';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+    EOS
+
+    it 'generates baselines for each example' do
+      run_diffux
+      expect(snapshot_file_exists?('foo', '@large', 'baseline.png')).to eq(true)
+      expect(snapshot_file_exists?('bar', '@large', 'baseline.png')).to eq(true)
+      expect(snapshot_file_exists?('baz', '@large', 'baseline.png')).to eq(true)
+    end
+  end
+
   describe 'when there are two examples with the same description' do
     let(:examples_js) { <<-EOS }
       diffux.define('#{description}', function() {

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -363,4 +363,39 @@ describe 'diffux_ci' do
         .to include("Error while defining \\\"#{description}\\\"")
     end
   end
+
+  describe 'when using fdefine' do
+    let(:examples_js) { <<-EOS }
+      diffux.define('foo', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Foo';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+
+      diffux.fdefine('bar', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Bar';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+
+      diffux.define('baz', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Baz';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+    EOS
+
+    it 'generates baselines for the fdefined example' do
+      run_diffux
+      expect(snapshot_file_exists?('foo', '@large', 'baseline.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?('bar', '@large', 'baseline.png'))
+        .to eq(true)
+      expect(snapshot_file_exists?('baz', '@large', 'baseline.png'))
+        .to eq(false)
+    end
+  end
 end

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -373,6 +373,13 @@ describe 'diffux_ci' do
         return elem;
       }, #{example_config});
 
+      diffux.fdefine('fiz', function() {
+        var elem = document.createElement('div');
+        elem.innerHTML = 'Fiz';
+        document.body.appendChild(elem);
+        return elem;
+      }, #{example_config});
+
       diffux.fdefine('bar', function() {
         var elem = document.createElement('div');
         elem.innerHTML = 'Bar';
@@ -388,10 +395,13 @@ describe 'diffux_ci' do
       }, #{example_config});
     EOS
 
-    it 'generates baselines for the fdefined example' do
+    it 'generates baselines for the fdefined examples' do
       run_diffux
+
       expect(snapshot_file_exists?('foo', '@large', 'baseline.png'))
         .to eq(false)
+      expect(snapshot_file_exists?('fiz', '@large', 'baseline.png'))
+        .to eq(true)
       expect(snapshot_file_exists?('bar', '@large', 'baseline.png'))
         .to eq(true)
       expect(snapshot_file_exists?('baz', '@large', 'baseline.png'))

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -10,14 +10,15 @@ describe 'diffux_ci' do
   end
 
   let(:example_config) { '{}' }
+  let(:description) { 'foo' }
 
   let(:examples_js) { <<-EOS }
-    diffux.define('foo', function() {
+    diffux.define('#{description}', function() {
       var elem = document.createElement('div');
       elem.innerHTML = 'Foo';
       document.body.appendChild(elem);
       return elem;
-    }, #{example_config})
+    }, #{example_config});
   EOS
 
   before do
@@ -49,9 +50,9 @@ describe 'diffux_ci' do
     end
   end
 
-  def snapshot_file_exists?(size, file_name)
+  def snapshot_file_exists?(description, size, file_name)
     File.exist?(
-      File.join(@tmp_dir, 'snapshots', 'foo', size, file_name)
+      File.join(@tmp_dir, 'snapshots', description, size, file_name)
     )
   end
 
@@ -62,9 +63,12 @@ describe 'diffux_ci' do
 
     it 'generates a baseline, but no diff' do
       run_diffux
-      expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-      expect(snapshot_file_exists?('@large', 'diff.png')).to eq(false)
-      expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+        .to eq(true)
+      expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+        .to eq(false)
     end
   end
 
@@ -80,9 +84,12 @@ describe 'diffux_ci' do
 
       it 'keeps the baseline, and creates no diff' do
         run_diffux
-        expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-        expect(snapshot_file_exists?('@large', 'diff.png')).to eq(false)
-        expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(false)
+        expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+          .to eq(true)
+        expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+          .to eq(false)
+        expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+          .to eq(false)
       end
     end
 
@@ -97,32 +104,35 @@ describe 'diffux_ci' do
 
           File.open(File.join(@tmp_dir, 'examples.js'), 'w') do |f|
             f.write(<<-EOS)
-              diffux.define('foo', function() {
+              diffux.define('#{description}', function() {
                 var elem = document.createElement('div');
                 elem.innerHTML = 'Football';
                 document.body.appendChild(elem);
                 return elem;
-              }, #{example_config})
+              }, #{example_config});
             EOS
           end
         end
 
         it 'keeps the baseline, and generates a diff' do
           run_diffux
-          expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-          expect(snapshot_file_exists?('@large', 'diff.png')).to eq(true)
-          expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(true)
+          expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+            .to eq(true)
+          expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+            .to eq(true)
+          expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+            .to eq(true)
         end
       end
     end
 
     context 'and the baseline does not have height' do
       let(:examples_js) { <<-EOS }
-        diffux.define('foo', function() {
+        diffux.define('#{description}', function() {
           var elem = document.createElement('div');
           document.body.appendChild(elem);
           return elem;
-        }, #{example_config})
+        }, #{example_config});
       EOS
 
       before do
@@ -130,21 +140,24 @@ describe 'diffux_ci' do
 
         File.open(File.join(@tmp_dir, 'examples.js'), 'w') do |f|
           f.write(<<-EOS)
-            diffux.define('foo', function() {
+            diffux.define('#{description}', function() {
               var elem = document.createElement('div');
               elem.innerHTML = 'Foo';
               document.body.appendChild(elem);
               return elem;
-            }, #{example_config})
+            }, #{example_config});
           EOS
         end
       end
 
       it 'keeps the baseline, and generates a diff' do
         run_diffux
-        expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-        expect(snapshot_file_exists?('@large', 'diff.png')).to eq(true)
-        expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(true)
+        expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+          .to eq(true)
+        expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+          .to eq(true)
+        expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+          .to eq(true)
       end
     end
   end
@@ -154,9 +167,12 @@ describe 'diffux_ci' do
 
     it 'generates the right baselines' do
       run_diffux
-      expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-      expect(snapshot_file_exists?('@small', 'baseline.png')).to eq(true)
-      expect(snapshot_file_exists?('@medium', 'baseline.png')).to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+        .to eq(true)
+      expect(snapshot_file_exists?(description, '@small', 'baseline.png'))
+        .to eq(true)
+      expect(snapshot_file_exists?(description, '@medium', 'baseline.png'))
+        .to eq(false)
     end
   end
 
@@ -180,8 +196,10 @@ describe 'diffux_ci' do
     context 'and the example has no `viewport` config' do
       it 'uses the first viewport in the config' do
         run_diffux
-        expect(snapshot_file_exists?('@foo', 'baseline.png')).to eq(true)
-        expect(snapshot_file_exists?('@bar', 'baseline.png')).to eq(false)
+        expect(snapshot_file_exists?(description, '@foo', 'baseline.png'))
+          .to eq(true)
+        expect(snapshot_file_exists?(description, '@bar', 'baseline.png'))
+          .to eq(false)
       end
     end
 
@@ -190,29 +208,34 @@ describe 'diffux_ci' do
 
       it 'uses the viewport to generate a baseline' do
         run_diffux
-        expect(snapshot_file_exists?('@foo', 'baseline.png')).to eq(false)
-        expect(snapshot_file_exists?('@bar', 'baseline.png')).to eq(true)
+        expect(snapshot_file_exists?(description, '@foo', 'baseline.png'))
+          .to eq(false)
+        expect(snapshot_file_exists?(description, '@bar', 'baseline.png'))
+          .to eq(true)
       end
     end
   end
 
   describe 'with doneCallback async argument' do
     let(:examples_js) { <<-EOS }
-      diffux.define('foo', function(done) {
+      diffux.define('#{description}', function(done) {
         setTimeout(function() {
           var elem = document.createElement('div');
           elem.innerHTML = 'Foo';
           document.body.appendChild(elem);
           done(elem);
         });
-      }, #{example_config})
+      }, #{example_config});
     EOS
 
     it 'generates a baseline, but no diff' do
       run_diffux
-      expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-      expect(snapshot_file_exists?('@large', 'diff.png')).to eq(false)
-      expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+        .to eq(true)
+      expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+        .to eq(false)
+      expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+        .to eq(false)
     end
 
     describe 'with a previous run' do
@@ -223,9 +246,12 @@ describe 'diffux_ci' do
 
         it 'keeps the baseline, and creates no diff' do
           run_diffux
-          expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-          expect(snapshot_file_exists?('@large', 'diff.png')).to eq(false)
-          expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(false)
+          expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+            .to eq(true)
+          expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+            .to eq(false)
+          expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+            .to eq(false)
         end
       end
 
@@ -236,23 +262,26 @@ describe 'diffux_ci' do
 
             File.open(File.join(@tmp_dir, 'examples.js'), 'w') do |f|
               f.write(<<-EOS)
-                diffux.define('foo', function(done) {
+                diffux.define('#{description}', function(done) {
                   setTimeout(function() {
                     var elem = document.createElement('div');
                     elem.innerHTML = 'Football';
                     document.body.appendChild(elem);
                     done(elem);
                   });
-                }, #{example_config})
+                }, #{example_config});
               EOS
             end
           end
 
           it 'keeps the baseline, and generates a diff' do
             run_diffux
-            expect(snapshot_file_exists?('@large', 'baseline.png')).to eq(true)
-            expect(snapshot_file_exists?('@large', 'diff.png')).to eq(true)
-            expect(snapshot_file_exists?('@large', 'candidate.png')).to eq(true)
+            expect(snapshot_file_exists?(description, '@large', 'baseline.png'))
+              .to eq(true)
+            expect(snapshot_file_exists?(description, '@large', 'diff.png'))
+              .to eq(true)
+            expect(snapshot_file_exists?(description, '@large', 'candidate.png'))
+              .to eq(true)
           end
         end
       end
@@ -261,7 +290,7 @@ describe 'diffux_ci' do
 
   describe 'when an example fails' do
     let(:examples_js) { <<-EOS }
-      diffux.define('foo', function() {
+      diffux.define('#{description}', function() {
         return undefined;
       });
     EOS
@@ -271,25 +300,26 @@ describe 'diffux_ci' do
     end
 
     it 'logs the error' do
-      expect(run_diffux[:std_err]).to include('Error while rendering "foo"')
+      expect(run_diffux[:std_err])
+        .to include("Error while rendering \"#{description}\"")
     end
   end
 
   describe 'when there are two examples with the same description' do
     let(:examples_js) { <<-EOS }
-      diffux.define('foo', function() {
+      diffux.define('#{description}', function() {
         var elem = document.createElement('div');
         elem.innerHTML = 'Foo';
         document.body.appendChild(elem);
         return elem;
-      }, #{example_config})
+      }, #{example_config});
 
-      diffux.define('foo', function() {
+      diffux.define('#{description}', function() {
         var elem = document.createElement('div');
         elem.innerHTML = 'Bar';
         document.body.appendChild(elem);
         return elem;
-      }, #{example_config})
+      }, #{example_config});
     EOS
 
     it 'exits with a non-zero exit code' do
@@ -297,7 +327,8 @@ describe 'diffux_ci' do
     end
 
     it 'logs the error' do
-      expect(run_diffux[:std_err]).to include('Error while defining \"foo\"')
+      expect(run_diffux[:std_err])
+        .to include("Error while defining \\\"#{description}\\\"")
     end
   end
 end


### PR DESCRIPTION
I sometimes want to focus on multiple examples at the same time. Now that we compile a list of descriptions, expanding `fdefine` to allow for multiple examples is fairly trivial. This also matches RSpec and Jasmine behavior, which is more likely what people will expect anyway.