### PR TITLE
Remove dependency on React

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ diffux.define('async component', function(done) {
 });
 ```
 
+### Cleaning up the DOM
+
+Diffux-CI will clean up the DOM in between rendered examples. If you need more
+control over the clean-up process you can override `diffux.cleanOutElement`
+with your own implementation. This is useful if you need to clean up event
+listeners for instance, or if you use
+[React](https://facebook.github.io/react/) and need to unmount components.
+
+```javascript
+diffux.cleanOutElement = function(element) {
+  React.unmountComponentAtNode(element);
+};
+```
+
 ## Installation
 
 Diffux-CI comes bundled as a gem. To install it, run `gem install diffux_ci`.

--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -106,15 +106,13 @@ window.diffux = {
     });
   },
 
-  cleanUpPreviousExample: function() {
-    if (this.currentRenderedElement) {
-      if (window.React) {
-        window.React.unmountComponentAtNode(document.body.lastChild);
-      } else {
-        this.currentRenderedElement.parentNode
-          .removeChild(this.currentRenderedElement);
-      }
-    }
+  /**
+   * Clean up the DOM for a rendered element that has already been processed.
+   *
+   * @param {Object} renderedElement
+   */
+  cleanOutElement: function(renderedElement) {
+    renderedElement.parentNode.removeChild(renderedElement);
   },
 
   /**
@@ -129,7 +127,9 @@ window.diffux = {
     }
 
     try {
-      this.cleanUpPreviousExample();
+      if (this.currentRenderedElement) {
+        this.cleanOutElement(this.currentRenderedElement);
+      }
       this.clearVisibleElements();
 
       var func = currentExample.func;
@@ -155,15 +155,6 @@ window.diffux = {
 
   processElem: function(currentExample, elem) {
     try {
-      // TODO: elem.getDOMNode is deprecated in React, so we need to convert
-      // this to ReactDOM.findDOMNode(elem) at some point, or push this
-      // requirement into the examples.
-      if (elem.getDOMNode) {
-        // Soft-dependency to React here. If the thing returned has a
-        // `getDOMNode` method, call it to get the real DOM node.
-        elem = elem.getDOMNode();
-      }
-
       this.currentRenderedElement = elem;
 
       var rect;


### PR DESCRIPTION
There was a soft dependency to React in that you could return a React
component from your examples instead of a DOM node. This dependency was
problematic in that we expected a globally defined `React` variable to
exist. I'm removing this dependency and moving the responsibility to the
examples instead.

To have a way to clean up event listeners and such, I'm adding a
`cleanOutElement` method that you can override. For React, this is where
you should unmount components.

Fixes #47