### PR TITLE
Simplify clearing out document between examples

### DIFF
--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -49,23 +49,6 @@ window.diffux = {
     }.bind(this));
   },
 
-  isElementVisible: function(element) {
-    // element.offsetParent is a cheap way to determine visibility for most
-    // elements, but it doesn't work for elements with fixed positioning so we
-    // will need to fall back to the more expensive getComputedStyle.
-    return element.offsetParent ||
-      window.getComputedStyle(element).display !== 'none';
-  },
-
-  clearVisibleElements: function() {
-    var allElements = document.querySelectorAll('body > *');
-    for (var element of allElements) {
-      if (this.isElementVisible(element)) {
-        element.parentNode.removeChild(element);
-      }
-    }
-  },
-
   handleError: function(currentExample, error) {
     console.error(error);
     return {
@@ -108,6 +91,9 @@ window.diffux = {
 
   /**
    * Clean up the DOM for a rendered element that has already been processed.
+   * This can be overridden by consumers to define their own clean out method,
+   * which can allow for this to be used to unmount React components, for
+   * example.
    *
    * @param {Object} renderedElement
    */
@@ -127,10 +113,13 @@ window.diffux = {
     }
 
     try {
+      // Clear out the body of the document
       if (this.currentRenderedElement) {
         this.cleanOutElement(this.currentRenderedElement);
       }
-      this.clearVisibleElements();
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
 
       var func = currentExample.func;
       if (func.length) {

--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -17,11 +17,11 @@
       <link rel="stylesheet" type="text/css"
         href="/resource?file=<%= ERB::Util.url_encode(stylesheet) %>">
     <% end %>
-  </head>
-  <body style="background-color: #fff; margin: 0; pointer-events: none;">
     <script src="/diffux_ci-runner.js"></script>
     <% @config['source_files'].each do |source_file| %>
       <script src="/resource?file=<%= ERB::Util.url_encode(source_file) %>"></script>
     <% end %>
+  </head>
+  <body style="background-color: #fff; margin: 0; pointer-events: none;">
   </body>
 </html>


### PR DESCRIPTION
We were previously just removing any visible elements from the body,
which requires a little overhead to determine if the element is visible.
I believe we were doing this to avoid removing our script tags which
were in the body. I think that if we move the script tags to the head,
we can do this more simply.

In my unscientific test, this didn't seem to have much of an impact on
performance, but it is simpler so I think it is still worth doing.