### PR TITLE
Simplify fdefine filtering

### DIFF
--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -28,15 +28,9 @@ window.diffux = {
    * @return {Array.<Object>}
    */
   getAllExamples: function() {
-    var descriptions = Object.keys(this.defined);
-
-    if (this.fdefined.length) {
-      // Some examples have been focused, so we want to filter out anything that
-      // has not been focused.
-      descriptions = descriptions.filter(function(description) {
-        return this.fdefined.indexOf(description) !== -1;
-      }.bind(this));
-    }
+    var descriptions = this.fdefined.length ?
+      this.fdefined :
+      Object.keys(this.defined);
 
     return descriptions.map(function(description) {
       var example = this.defined[description];


### PR DESCRIPTION
I realized that we were filtering the descriptions down to be the same
array as `this.fdefine`, so we can just totally skip that step and just
use `this.fdefine` instead.