### PR TITLE
Make sure renderExample() errors gracefully

### DIFF
--- a/lib/public/diffux_ci-runner.js
+++ b/lib/public/diffux_ci-runner.js
@@ -96,17 +96,21 @@ window.diffux = {
   },
 
   /**
+   * This function is called from Ruby asynchronously. Therefore, we need to
+   * call doneFunc when the method has completed so that Ruby knows to continue.
+   *
    * @param {String} exampleDescription
    * @param {Function} doneFunc injected by driver.execute_async_script in
    *   diffux_ci_runner.rb
    */
   renderExample: function(exampleDescription, doneFunc) {
-    var currentExample = this.defined[exampleDescription];
-    if (!currentExample) {
-      throw 'No example found with description "' + exampleDescription + '"';
-    }
-
     try {
+      var currentExample = this.defined[exampleDescription];
+      if (!currentExample) {
+        throw new Error(
+          'No example found with description "' + exampleDescription + '"');
+      }
+
       // Clear out the body of the document
       if (this.currentRenderedElement) {
         this.cleanOutElement(this.currentRenderedElement);


### PR DESCRIPTION
We call this function asynchronously from Ruby. In order for it to know
what is happening, we need to make sure that doneFunc() is called. Since
we already have a catch block wired up, we can just move our throw into
there and we should be good to go.

I added a comment to help explain this bit of weirdness for the future.
I also decided to throw a new Error object to give us more context here,
like a stack trace, if we end up wanting that.