### PR TITLE
Avoid cropping unless we actually need it

### DIFF
--- a/lib/diffux_ci_runner.rb
+++ b/lib/diffux_ci_runner.rb
@@ -121,7 +121,7 @@ begin
       screenshot = ChunkyPNG::Image.from_blob(driver.screenshot_as(:png))
       print '.'
 
-      # In our JavScript we are rounding up, which can sometimes give us a
+      # In our JavaScript we are rounding up, which can sometimes give us a
       # dimensions that are larger than the screenshot dimensions. We need to
       # guard against that here.
       crop_width = [

--- a/lib/diffux_ci_runner.rb
+++ b/lib/diffux_ci_runner.rb
@@ -133,11 +133,13 @@ begin
         screenshot.height - rendered['top']
       ].min
 
-      screenshot.crop!(rendered['left'],
-                       rendered['top'],
-                       crop_width,
-                       crop_height)
-      print '.'
+      if crop_width < screenshot.width || crop_height < screenshot.height
+        screenshot.crop!(rendered['left'],
+                         rendered['top'],
+                         crop_width,
+                         crop_height)
+        print '.'
+      end
 
       # Run the diff if needed
       baseline_path = DiffuxCIUtils.path_to(


### PR DESCRIPTION
Under the hood, this will cause ChunkyPNG to allocate a new array of
pixels for the cropped image, and then slice out the pixels needed for
the cropped image from the uncropped image and put them into the new
array. If we don't actually need to crop, we can avoid this work and
memory allocation.

In the Brigade diffux test suite this seemed to happen a few times, but
not enough to make a noticeable difference in performance. Still, since
it is such an easy thing to do, we might as well do it.