### PR TITLE
Make s3 bucket name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ viewports:
     height: 444
 s3_access_key_id: <your acccess key id>
 s3_secret_access_key: <your secret acccess key>
+s3_bucket_name: <a globally unique bucket name>
 ```
 
 ## Command line tools
@@ -161,8 +162,8 @@ and you can do use your developer tools to debug.
 ### `diffux upload_diffs`
 
 Uploads all current diff images to an Amazon S3 account and reports back URLs
-to access those diff images. Requires the `s3_access_key_id` and
-`s3_secret_access_key` configuration options.
+to access those diff images. Requires the `s3_access_key_id`,
+`s3_secret_access_key`, and `s3_bucket_name` configuration options.
 
 ### `diffux clean`
 

--- a/lib/diffux_ci_uploader.rb
+++ b/lib/diffux_ci_uploader.rb
@@ -3,11 +3,10 @@ require 's3'
 require 'securerandom'
 
 class DiffuxCIUploader
-  BUCKET_NAME = 'diffux_ci-diffs'
-
   def initialize
     @s3_access_key_id = DiffuxCIUtils.config['s3_access_key_id']
     @s3_secret_access_key = DiffuxCIUtils.config['s3_secret_access_key']
+    @s3_bucket_name = DiffuxCIUtils.config['s3_bucket_name']
   end
 
   def upload_diffs
@@ -42,10 +41,10 @@ class DiffuxCIUploader
   def find_or_build_bucket
     service = S3::Service.new(access_key_id: @s3_access_key_id,
                               secret_access_key: @s3_secret_access_key)
-    bucket = service.buckets.find(BUCKET_NAME)
+    bucket = service.buckets.find(@s3_bucket_name)
 
     if bucket.nil?
-      bucket = service.buckets.build(BUCKET_NAME)
+      bucket = service.buckets.build(@s3_bucket_name)
       bucket.save(location: :us)
     end
 


### PR DESCRIPTION
I came across a bug trying to upload diffs locally. It turns out that
bucket names need to be globally unique (not only unique for an
account). I'm adding a new configuration option to resolve this.

Fixes #60