### PR TITLE
Use base64 encoding for folder names

### DIFF
--- a/lib/diffux_ci-diffs.html.erb
+++ b/lib/diffux_ci-diffs.html.erb
@@ -1,3 +1,4 @@
+<% require 'rack' %>
 <!DOCTYPE html>
 <html>
   <head>
@@ -9,7 +10,7 @@
 
     <% diff_images.each do |diff| %>
       <h3>
-        <%= diff[:description] %> @ <%= diff[:viewport] %>
+        <%= Rack::Utils.escape_html(diff[:description]) %> @ <%= diff[:viewport] %>
       </h3>
       <p><img src="<%= diff[:url] %>"></p>
     <% end %>

--- a/lib/diffux_ci_server.rb
+++ b/lib/diffux_ci_server.rb
@@ -9,6 +9,12 @@ class DiffuxCIServer < Sinatra::Base
     set :port, DiffuxCIUtils.config['port']
   end
 
+  helpers do
+    def h(text)
+      Rack::Utils.escape_html(text)
+    end
+  end
+
   get '/' do
     @config = DiffuxCIUtils.config
     erb :index

--- a/lib/diffux_ci_utils.rb
+++ b/lib/diffux_ci_utils.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'erb'
 require 'uri'
+require 'base64'
 
 class DiffuxCIUtils
   def self.config
@@ -33,7 +34,7 @@ class DiffuxCIUtils
   end
 
   def self.normalize_description(description)
-    description.gsub(/[^a-zA-Z0-9\-_]/, '_')
+    Base64.encode64(description)
   end
 
   def self.path_to(description, viewport_name, file_name)
@@ -59,7 +60,7 @@ class DiffuxCIUtils
       viewport_dir = File.expand_path('..', file)
       description_dir = File.expand_path('..', viewport_dir)
       {
-        description: File.basename(description_dir),
+        description: Base64.decode64(File.basename(description_dir)),
         viewport: File.basename(viewport_dir).sub('@', ''),
         file: file
       }

--- a/lib/views/review.erb
+++ b/lib/views/review.erb
@@ -9,7 +9,7 @@
     <h2>DIFFS</h2>
     <% @snapshots[:diffs].each do |diff| %>
       <h3>
-        <%= diff[:description] %> @ <%= diff[:viewport] %>
+        <%= h diff[:description] %> @ <%= diff[:viewport] %>
       </h3>
       <p><img src="/resource?file=<%= ERB::Util.url_encode(diff[:file]) %>"></p>
       <form style="display: inline-block"
@@ -29,7 +29,7 @@
     <h2>BASELINES</h2>
     <% @snapshots[:baselines].each do |baseline| %>
       <h3>
-        <%= baseline[:description] %> @ <%= baseline[:viewport] %>
+        <%= h baseline[:description] %> @ <%= baseline[:viewport] %>
       </h3>
       <p><img src="/resource?file=<%= ERB::Util.url_encode(baseline[:file]) %>"></p>
     <% end %>

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'tmpdir'
 require 'open3'
+require 'base64'
 
 describe 'diffux_ci' do
   let(:config) do
@@ -52,7 +53,8 @@ describe 'diffux_ci' do
 
   def snapshot_file_exists?(description, size, file_name)
     File.exist?(
-      File.join(@tmp_dir, 'snapshots', description, size, file_name)
+      File.join(@tmp_dir, 'snapshots',
+                Base64.encode64(description), size, file_name)
     )
   end
 

--- a/spec/diffux_ci_utils_spec.rb
+++ b/spec/diffux_ci_utils_spec.rb
@@ -1,4 +1,5 @@
 require 'diffux_ci_utils'
+require 'base64'
 
 describe 'DiffuxCIUtils' do
   before do
@@ -47,7 +48,7 @@ describe 'DiffuxCIUtils' do
 
     context 'with special characters' do
       let(:description) { '<MyComponent> something interesting' }
-      it { should eq('_MyComponent__something_interesting') }
+      it { should eq(Base64.encode64(description)) }
     end
   end
 
@@ -56,6 +57,6 @@ describe 'DiffuxCIUtils' do
     let(:description) { '<MyComponent>' }
     let(:viewport_name) { 'large' }
     let(:file_name) { 'diff.png' }
-    it { should eq('./snapshots/_MyComponent_/@large/diff.png') }
+    it { should eq("./snapshots/#{Base64.encode64(description)}/@large/diff.png") }
   end
 end


### PR DESCRIPTION
A problem with using the filesystem directly as the storage for
snapshots and diffs is that we've had to escape example descriptions in
order to use them as valid folder names. In #40, @lencioni and I have
discussed using base64 encoding to use as folder names. The upside is
that we can keep the real description throughout the UI (no more
weird underscores on the review screen). The downside is that the
structure is now obfuscated to a certain degree. What would before look
like this

snapshots
  |- _Foo_
      |- @320
         |- baseline.png
  |- _Bar_
      |- @320
         |- baseline.png
         |- diff.png
         |- candidate.png

Will now look like this

snapshots
  |- PEZvbz4NCg==
      |- @320
         |- baseline.png
  |- PEJhcj4NCg==
      |- @320
         |- baseline.png
         |- diff.png
         |- candidate.png

This probably doesn't matter, as the folder structure is an
implementation detail and not something that we expose. But if we find
out that it's hard to work with, we can provide tools to improve the UX
while still keeping the base64 encoding.