### PR TITLE
Allow for async examples to return Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,23 @@ diffux.define('dialog window', function() {
 ### Async examples
 
 If your examples need to do something asynchronous before they finish render,
-you can use the `done` callback passed in to the define method.
+you can return a `Promise` from your define method that resolves with the
+element.
+
+```javascript
+diffux.define('async component', function() {
+  return new Promise(function(resolve) {
+    var elem = document.createElement('div');
+    document.body.appendChild(elem);
+    setTimeout(function() {
+      elem.innerHTML = 'Async content loaded';
+      resolve(elem);
+    }, 100);
+  });
+});
+```
+
+Alternatively, use the `done` callback passed in to the define method.
 
 ```javascript
 diffux.define('async component', function(done) {
@@ -88,7 +104,7 @@ diffux.define('async component', function(done) {
   setTimeout(function() {
     elem.innerHTML = 'Async content loaded';
     done(elem);
-  }, 100)
+  }, 100);
 });
 ```
 

--- a/lib/diffux_ci/public/diffux_ci-runner.js
+++ b/lib/diffux_ci/public/diffux_ci-runner.js
@@ -132,8 +132,21 @@ window.diffux = {
       } else {
         // The function does not take an argument, so we can run it
         // synchronously.
-        var elem = func();
-        doneFunc(this.processElem(currentExample, elem));
+        var result = func();
+
+        if (result instanceof Promise) {
+          // The function returned a promise, so we need to wait for it to
+          // resolve before proceeding.
+          result.then(function(elem) {
+            doneFunc(this.processElem(currentExample, elem));
+          }.bind(this)).catch(function(error) {
+            doneFunc(this.handleError(currentExample, error));
+          }.bind(this));
+        } else {
+          // The function did not return a promise, so we assume it gave us an
+          // element that we can process immediately.
+          doneFunc(this.processElem(currentExample, result));
+        }
       }
     } catch (error) {
       doneFunc(this.handleError(currentExample, error));


### PR DESCRIPTION
This is similar to how Mocha works. In Mocha, async tests can either
take a `done` callback or return a `Promise`. This gives us a slightly
nicer API for working with asynchronous examples.

Fixes #77.

cc: @serena-w