### PR TITLE
Add Ruby 2.3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
 
 script: bash headless_rspec.sh
 install: gem install rspec headless; bundle install;


### PR DESCRIPTION
This helps us ensure that our code will continue to work on newer
versions of Ruby.