### PR TITLE
Prevent newlines in directory names

### DIFF
--- a/lib/diffux_ci/utils.rb
+++ b/lib/diffux_ci/utils.rb
@@ -35,7 +35,7 @@ module DiffuxCI
     end
 
     def self.normalize_description(description)
-      Base64.encode64(description).strip
+      Base64.strict_encode64(description).strip
     end
 
     def self.path_to(description, viewport_name, file_name)

--- a/spec/diffux_ci/utils_spec.rb
+++ b/spec/diffux_ci/utils_spec.rb
@@ -48,7 +48,17 @@ describe DiffuxCI::Utils do
 
     context 'with special characters' do
       let(:description) { '<MyComponent> something interesting' }
-      it { should eq(Base64.encode64(description).strip) }
+      it { should eq(Base64.strict_encode64(description).strip) }
+    end
+
+    context 'when very long' do
+      let(:description) { <<-EOS }
+        <MyComponent> something interesting and something that ends up being
+        very very long for some reason which might end up causing problems
+        depending on how we encode the description
+      EOS
+
+      it { is_expected.to_not include "\n" }
     end
   end
 
@@ -57,6 +67,6 @@ describe DiffuxCI::Utils do
     let(:description) { '<MyComponent>' }
     let(:viewport_name) { 'large' }
     let(:file_name) { 'diff.png' }
-    it { should eq("./snapshots/#{Base64.encode64(description).strip}/@large/diff.png") }
+    it { should eq("./snapshots/#{Base64.strict_encode64(description).strip}/@large/diff.png") }
   end
 end

--- a/spec/diffux_ci_spec.rb
+++ b/spec/diffux_ci_spec.rb
@@ -54,7 +54,7 @@ describe 'diffux_ci' do
   def snapshot_file_exists?(description, size, file_name)
     File.exist?(
       File.join(@tmp_dir, 'snapshots',
-                Base64.encode64(description).strip, size, file_name)
+                Base64.strict_encode64(description).strip, size, file_name)
     )
   end
 


### PR DESCRIPTION
It turns out that Base64.encode64 adds newlines after a certain length.
This ends up causing problems when used in filenames. Instead, we can
use Base64.strict_encode64, which does the same thing but without
newlines.

Fixes #76.