### PR TITLE
Allow additional directories to be specified in the config

### DIFF
--- a/lib/diffux_ci/server.rb
+++ b/lib/diffux_ci/server.rb
@@ -38,6 +38,21 @@ module DiffuxCI
       end
     end
 
+    get '/*' do
+      config = DiffuxCI::Utils.config
+      file = params[:splat].first
+      if File.exist?(file)
+        send_file file
+      else
+        config['public_directories'].each do |pub_dir|
+          filepath = File.join(Dir.pwd, pub_dir, file)
+          if File.exist?(filepath)
+            send_file filepath
+          end
+        end
+      end
+    end
+
     post '/reject' do
       DiffuxCI::Action.new(params[:description], params[:viewport]).reject
       redirect back

--- a/lib/diffux_ci/utils.rb
+++ b/lib/diffux_ci/utils.rb
@@ -10,6 +10,7 @@ module DiffuxCI
         'snapshots_folder' => './snapshots',
         'source_files' => [],
         'stylesheets' => [],
+        'public_directories' => [],
         'port' => 4567,
         'driver' => :firefox,
         'viewports' => {


### PR DESCRIPTION
I added a way for diffux to be configured to look for resources in other
directories. This allows the usage of custom fonts and resolves the issue
https://github.com/diffux/diffux_ci/issues/82. I also added a test to
check that diffux can find files in other directories specified in its
config.

fixes #82 